### PR TITLE
No redirection by default (401 UNAUTHORIZED instead)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ It is as simple as `require('permission')`, because you do want to _require perm
 	})
 
 Pass an array determining which roles one controller supports. 
-Pass an _empty array_ if you want to allow any role to be authorized,
- but still to be authenticated (signed in).
+Leave empty if you want to allow any role to be authorized, but still to be authenticated (signed in).
+Pass an empty array to ensure nobody has access, even when authenticated. 
 
 	router.get('/', require('permission')(), function(req, res) {
     	res.render('profile');
@@ -37,7 +37,7 @@ There are 2 default values in _permission_ module:
 - route for no permission
 
 Default role property is searched in Express' user role property, `req.user.role`. 
-Route for redirection when user doesn't have permission is `/login`.
+If the user doesn't have permission, a 401 is returned. You can also setup a redirection.
 
 To override these 2 values, do the following on your `app` configuration:
 

--- a/index.js
+++ b/index.js
@@ -15,14 +15,14 @@ module.exports = function(roles){
     /**
      * Default configuration
      */
-    var noPermissionRedirect  = '/login';
+    var noPermissionRedirect  = null;
     var role                  = 'role';
 
     /**
      * Default configuration is overriden
      */
     if (req.app.get('permission')){
-      if (req.app.get('permission').noPermissionRedirect) {
+      if ('noPermissionRedirect' in req.app.get('permission')) {
         noPermissionRedirect = req.app.get('permission').noPermissionRedirect;
       }
       if (req.app.get('permission').role){
@@ -40,12 +40,17 @@ module.exports = function(roles){
         next();
       } else if (roles.indexOf(req.user[role]) > -1){
         next();
-      } else {
+      } else if (noPermissionRedirect != null) {
         res.redirect(noPermissionRedirect);
+      } else {
+        res.status(401).send(null);
       }
     }
-    else {
+    else if (noPermissionRedirect != null) {
       res.redirect(noPermissionRedirect);
+    }
+    else {
+      res.status(401).send(null);
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "permission",
-  "version": "0.1.5",
-  "description": "Make user permissions for views based on roles.",
+  "version": "0.1.6",
+  "description": "Handle user permissions for routes based on roles.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -18,6 +18,9 @@
     "authentication"
   ],
   "author": "Tomislav Tenodi <tomislav.tenodi@gmail.com>",
+  "contributors": [
+    "Lubert Theo <theo.lubert@gmail.com>"
+  ],
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
Ignore redirection by default, using standard 401 HTTP response code.
Also a small fix in the doc:
- no argument => all roles have access, only needs authenticated user
- empty array => no access
